### PR TITLE
Odstranění čísla městské části z řádku s místem a datem.

### DIFF
--- a/mail_service/zadosti.js
+++ b/mail_service/zadosti.js
@@ -96,21 +96,29 @@ function sendMail(data) {
     }
 
     if (data.recipients["pojistovna"]) {
-        attachments.push(
-            HTTP.post(
-                `${baseURL}/pojistovna`, {
-                    headers: defaultHeaders,
-                    data: JSON.stringify({
-                        recipient: data.recipients["pojistovna"],
-                        applicant: data.applicant,
-                        reply_to: data.reply_to,
-                        reason: data.reason
+        const createPojistovnaAttachment = (pojistovna) => {
+            attachments.push(
+                HTTP.post(
+                    `${baseURL}/pojistovna`, {
+                        headers: defaultHeaders,
+                        data: JSON.stringify({
+                            recipient: pojistovnaData,
+                            applicant: data.applicant,
+                            reply_to: data.reply_to,
+                            reason: data.reason
+                        })
+                    }, {
+                        filename: `${pojistovna.name}.pdf`,
+                        type: "application/pdf"
                     })
-                }, {
-                    filename: "pojistovna.pdf",
-                    type: "application/pdf"
-                })
-        );
+            );
+        }
+        const pojistovnaData = data.recipients["pojistovna"]
+        if (Array.isArray(pojistovnaData)) {
+            pojistovnaData.forEach(createPojistovnaAttachment)
+        } else {
+            createPojistovnaAttachment(pojistovnaData)
+        }
     }
 
     return {

--- a/transformation_service/templates/common.xsl
+++ b/transformation_service/templates/common.xsl
@@ -13,7 +13,7 @@
                 <xsl:apply-templates select="/json/recipient"/>
                 <section class="datum-misto">
                     <div>
-                        <xsl:value-of select="/json/applicant/address/city"/>
+                        <xsl:value-of select="replace(/json/applicant/address/city, ' \d+', '')"/>
                         <xsl:text> </xsl:text>
                         <xsl:value-of select="format-date(current-date(), '[D].&#x2009;[M].&#x2009;[Y]')"/>
                     </div>


### PR DESCRIPTION
V řádku s místem a datem se vypisovalo i číslo městské části, např. „Praha 4 11. 9. 2021“. Nově se bude číslo na konci městské části odstraňovat.