### PR TITLE
Alternativní názvy pojišťoven pro vytváření zkratek v názvech souborů v e-mailových přílohách.

### DIFF
--- a/mail_service/zadosti.js
+++ b/mail_service/zadosti.js
@@ -15,12 +15,17 @@ const defaultHeaders = {
 
 const pojistovny = {
     "Všeobecná zdravotní pojišťovna": "VZP",
+    "VŠEOBECNÁ ZDRAVOTNÍ POJIŠŤOVNA ČESKÉ REPUBLIKY": "VZP",
     "Oborová zdravotní pojišťovna zaměstnanců bank, pojišťoven a stavebnictví": "OZP",
+    "Oborová zdravotní pojišťovna": "OZP",
     "Česká průmyslová zdravotní pojišťovna": "CPZP",
     "Vojenská zdravotní pojišťovna České republiky": "VoZP",
+    "Vojenská zdravotní pojišťovna": "VoZP",
     "Zaměstnanecká pojišťovna Škoda": "ZPS",
     "RBP, zdravotní pojišťovna": "RBP-ZP",
-    "Zdravotní pojišťovna ministerstva vnitra České republiky": "ZP MV CR"
+    "Revírní bratrská pokladna – zdravotní pojišťovna": "RBP-ZP",
+    "Zdravotní pojišťovna ministerstva vnitra České republiky": "ZP MV CR",
+    "Zdravotní pojišťovna Ministerstva vnitra ČR": "ZP MV CR"
 }
 
 


### PR DESCRIPTION
Jména ZP v pdf můžou být dvě – jedno z checkboxu bez adresy a pokud se povede API volání, je oficiální jméno i s adresou+datovkou z czechpointu/OVM.